### PR TITLE
Docs fixes and allow for integer lat lon

### DIFF
--- a/docs/src/Milankovitch.md
+++ b/docs/src/Milankovitch.md
@@ -140,6 +140,7 @@ To use time-varying orbital parameters in your insolation calculations:
 ```julia
 using Insolation
 using Dates
+using ClimaParams
 
 # Load orbital data (do this once, it's computationally expensive)
 orbital_data = OrbitalDataSplines()

--- a/docs/src/SolarGeometry.md
+++ b/docs/src/SolarGeometry.md
@@ -32,7 +32,7 @@ The **true anomaly** $A$ is the actual angular position of the planet in its ell
 
 The true anomaly is computed from the mean anomaly using a series expansion,
 ```math
-A = M + \left( 2e - \frac{1}{4}e^{3} \right) \sin(M) + \frac{5}{4} e^2 \sin(2M) + \frac{13}{12} e^3 \sin(3M),
+A = M + \left( 2e - \frac{1}{4}e^{3} \right) \sin(M) + \frac{5}{4} e^2 \sin(2M) + \frac{13}{12} e^3 \sin(3M) + \mathcal{O}(e^4),
 ```
 where $e$ is the orbital eccentricity. This series approximation is accurate to order $e^3$ and is sufficient for Earth's relatively circular orbit ($e \approx 0.017$).
 
@@ -42,7 +42,7 @@ The **solar longitude** $L_s$ (also called ecliptic longitude or true longitude)
 ```math
 L_s = A + \varpi.
 ```
-For Earth, $\varpi$ varies slowly due to precession (period $\sim$21,000 years).
+For Earth, $\varpi$ varies slowly due to precession (period $\sim 21{,}000$ years).
 
 ## Declination
 

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -48,6 +48,9 @@ end
 # instead of: insolation.(dates, lats, lons, Ref(params))
 Base.broadcastable(x::InsolationParameters) = tuple(x)
 
+# Allows inference of parameter type 
+Base.eltype(::InsolationParameters{FT}) where {FT} = FT
+
 # Method wrappers
 # This loop creates getter functions for each field, e.g.:
 # `year_anom(ps::AIP) = ps.year_anom`

--- a/src/SolarGeometry.jl
+++ b/src/SolarGeometry.jl
@@ -255,8 +255,8 @@ end
 """
     solar_geometry(
         date::DateTime,
-        latitude::FT,
-        longitude::FT,
+        latitude::Real,
+        longitude::Real,
         (ϖ, γ, e)::Tuple{FT, FT, FT},
         param_set::AIP;
         eot_correction::Bool = true,
@@ -270,8 +270,8 @@ at a specific time and location.
 
 # Arguments
 - `date::DateTime`: Current date and time
-- `latitude::FT`: Latitude [degrees]
-- `longitude::FT`: Longitude [degrees]
+- `latitude::Real`: Latitude [degrees]
+- `longitude::Real`: Longitude [degrees]
 - `(ϖ, γ, e)::Tuple{FT, FT, FT}`: Orbital parameters tuple containing:
   - `ϖ`: Longitude of perihelion [radians]
   - `γ`: Obliquity (axial tilt) [radians]
@@ -286,14 +286,14 @@ at a specific time and location.
 """
 function solar_geometry(
     date::DateTime,
-    latitude::FT,
-    longitude::FT,
+    latitude::Real,
+    longitude::Real,
     (ϖ, γ, e)::Tuple{FT, FT, FT},
     param_set::AIP;
     eot_correction = true,
 ) where {FT}
-    ϕ = deg2rad(latitude)
-    λ = deg2rad(longitude)
+    ϕ = eltype(param_set)(deg2rad(latitude))
+    λ = eltype(param_set)(deg2rad(longitude))
 
     # Get time since epoch in anomalistic years
     Δt_years = years_since_epoch(param_set, date)

--- a/test/test_insolation.jl
+++ b/test/test_insolation.jl
@@ -35,6 +35,20 @@ F, S, μ, ζ = insolation(date, lat, lon, param_set, od; milankovitch = true)
 @test S ≈ IP.tot_solar_irrad(param_set) rtol = rtol_insol
 @test μ ≈ 0.0 atol = atol
 
+# Test equivalence of mixed lat/lon types 
+@test insolation(date, lat, Int(lon), param_set, od; milankovitch = true) ==
+      (F, S, μ, ζ)
+@test insolation(date, Int(lat), lon, param_set, od; milankovitch = true) ==
+      (F, S, μ, ζ)
+@test insolation(
+    date,
+    Int(lat),
+    Int(lon),
+    param_set,
+    od;
+    milankovitch = true,
+) == (F, S, μ, ζ)
+
 # polar night NH 2
 date = Dates.DateTime(2020, 12, 20, 23, 0, 0)
 Δt_years = Insolation.years_since_epoch(param_set, date)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Allows users to use `insolation` and `daily_insolation` with integer latitude and longitude values.
Plus, a few docs clarifications. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
Add a test demonstrating this

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
