### PR TITLE
Revert ClimaParams to a weakdep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 authors = ["Climate Modeling Alliance"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "1.1.0"
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+
+[weakdeps]
+ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 
 [extensions]
 CreateParametersExt = "ClimaParams"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Fixes #100 

Alternatively, the ClimaParams ext code can be moved into src.

## To-do
As a follow up to this, a patch release should be made. The same thing should then be done in the coupler.
This would allow using all versions of 1.10 in the coupler and atmos.  

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
