### PR TITLE
Documentation; interpolation fixes (TSI and Milankovitch); changed use of semi-major axis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,13 +14,15 @@
   expressed in units of the semi-major axis (≈ AU for Earth) rather than meters.
   Multiply by the semi-major axis to recover a physical distance. The flux is
   `S0 / d^2`. This does not affect `F`, `S`, `μ`, or `ζ`.
+  - The equation of time is now computed from the exact equatorial projection of the
+  Sun's ecliptic longitude (`Δη = L − α`, with `α = atan2(cosγ sinLₛ, cosLₛ)`)
+  instead of the small-obliquity expansion `tan²(γ/2)`. It reduces to the previous
+  formula for small tilt but remains valid for any obliquity (e.g., Uranus-like). This
+  leads to tiny changes in insolation (shift by up to about 45 s in time), possibly
+  breaking downstream bitwise reproducibility tests.
 
 ### Bug fixes
 
-- The equation of time is now computed from the exact equatorial projection of the
-  Sun's ecliptic longitude (`Δη = L − α`, with `α = atan2(cosγ sinLₛ, cosLₛ)`)
-  instead of the small-obliquity expansion `tan²(γ/2)`. It reduces to the previous
-  formula for small tilt but remains valid for any obliquity (e.g., Uranus-like).
 - Fixed an interval-selection bug in `TSIDataSpline`'s `evaluate` that produced a
   small non-physical discontinuity in the interpolated total solar irradiance for
   dates after the 15th of a month but before noon.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,62 @@
+# Insolation.jl Release Notes
+
+## v1.2.0
+
+### Breaking changes
+
+- Removed the `orbit_semimaj` field from `InsolationParameters` (and the
+  `length_orbit_semi_major` ClimaParams mapping). The total solar irradiance
+  `tot_solar_irrad` is defined at the *mean* orbital distance (the semi-major
+  axis), so the absolute orbit size cancels out of the insolation and is no longer
+  needed. As a result, the planet-star distance `d` returned by `solar_geometry`,
+  `daily_distance_zenith_angle`, and `planet_star_distance` (and accepted by the
+  low-level `solar_flux`/`insolation(θ, d, …)` methods) is now **dimensionless**,
+  expressed in units of the semi-major axis (≈ AU for Earth) rather than meters.
+  Multiply by the semi-major axis to recover a physical distance. The flux is
+  `S0 / d^2`. This does not affect `F`, `S`, `μ`, or `ζ`.
+
+### Bug fixes
+
+- The equation of time is now computed from the exact equatorial projection of the
+  Sun's ecliptic longitude (`Δη = L − α`, with `α = atan2(cosγ sinLₛ, cosLₛ)`)
+  instead of the small-obliquity expansion `tan²(γ/2)`. It reduces to the previous
+  formula for small tilt but remains valid for any obliquity (e.g., Uranus-like).
+- Fixed an interval-selection bug in `TSIDataSpline`'s `evaluate` that produced a
+  small non-physical discontinuity in the interpolated total solar irradiance for
+  dates after the 15th of a month but before noon.
+- The Milankovitch (paleoclimate) path now indexes the Laskar et al. (2004) orbital
+  tables in Julian years, matching the tables' native time axis, instead of
+  anomalistic years. This slightly changes time-varying orbital-parameter results,
+  most noticeably at deep-time extremes.
+- `solar_geometry` and `daily_distance_zenith_angle` now convert all inputs to
+  `eltype(param_set)` internally, removing silent floating-point type mixing (e.g.,
+  Float32 parameter sets no longer leak Float64 into the result).
+
+### Enhancements
+
+- Added `julian_years_since_epoch` for computing time since epoch in Julian years
+  (the unit of the Laskar tables), complementing the anomalistic-year
+  `years_since_epoch`.
+- Made the solar azimuth calculation robust at high declinations by removing a
+  `tan(δ)` singularity (relevant for extreme-obliquity configurations).
+- Documentation audit: corrected physical descriptions and stale examples,
+  standardized docstrings, and added a type-level docstring for
+  `InsolationParameters`. Documented that the `true_anomaly` series (and the
+  quantities derived from it) is a low-eccentricity approximation that should be
+  replaced by an exact Kepler solver for highly eccentric orbits.
+- Clarified that `tot_solar_irrad` is the total solar irradiance at the *mean*
+  orbital distance (the semi-major axis), consistent with ClimaParams (earlier docs
+  incorrectly described this as "at 1 au").
+- Documented that the `TSIDataSpline` is the Sun's irradiance at 1 au and is
+  therefore meaningful for Earth only: in the flux calculation it is taken as the
+  irradiance at the planet's mean orbital distance, which holds only because
+  Earth's semi-major axis is ≈ 1 au (the package does not rescale it for other
+  bodies).
+
+### Notes
+
+- The signatures of `solar_geometry` and `daily_distance_zenith_angle` were widened
+  to accept any tuple of real-valued orbital parameters; existing calls are
+  unaffected.
+- Several bug fixes change numerical results slightly for deep-time Milankovitch
+  calculations and for time-varying TSI (1e-3 W/m2 interpolation errors corrected)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 authors = ["Climate Modeling Alliance"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/GettingStarted.md
+++ b/docs/src/GettingStarted.md
@@ -41,17 +41,17 @@ Insolation calculations require a parameter set containing orbital and physical 
 using ClimaParams
 params = InsolationParameters(Float64)
 
-# Without ClimaParams, specify all parameters manually:
+# Without ClimaParams, specify all parameters manually (values below
+# approximate the ClimaParams defaults for modern Earth):
 params = InsolationParameters{Float64}(
     year_anom = 365.259636 * 86400.0,  # Anomalistic year [s]
     day = 86400.0,                      # Day length [s]
-    orbit_semimaj = 1.496e11,           # Semi-major axis [m]
-    eccentricity_epoch = 0.0167,        # Eccentricity
-    obliq_epoch = deg2rad(23.44),       # Obliquity [rad]
-    lon_perihelion_epoch = deg2rad(282.95),  # Longitude of perihelion [rad]
-    tot_solar_irrad = 1362.0,           # Solar irradiance at 1 AU [W/m²]
-    epoch = DateTime(2000, 1, 1, 11, 58, 56, 816),  # J2000 epoch
-    mean_anom_epoch = deg2rad(357.5291)  # Mean anomaly at epoch [rad]
+    eccentricity_epoch = 0.016708634,   # Eccentricity [unitless]
+    obliq_epoch = deg2rad(23.43278),    # Obliquity [rad]
+    lon_perihelion_epoch = deg2rad(282.9373),  # Longitude of perihelion [rad]
+    tot_solar_irrad = 1362.0,           # Solar irradiance at mean orbital distance [W m⁻²]
+    epoch = DateTime(2000, 1, 1, 11, 58, 55, 816),  # J2000 epoch (UTC)
+    mean_anom_epoch = deg2rad(357.52911)  # Mean anomaly at epoch [rad]
 )
 ```
 
@@ -108,7 +108,7 @@ orb_params = orbital_params(params)
 # Calculate solar geometry
 (; d, θ, ζ) = solar_geometry(date, lat, lon, orb_params, params)
 
-println("Sun-Earth distance: $(d / 1.496e11) AU")
+println("Sun-Earth distance: $(d) (in units of the semi-major axis; ≈ AU for Earth)")
 println("Solar zenith angle: $(rad2deg(θ))°")
 println("Solar azimuth angle: $(rad2deg(ζ))°")
 ```

--- a/docs/src/InsolationExamples.md
+++ b/docs/src/InsolationExamples.md
@@ -20,19 +20,21 @@ od = OrbitalDataSplines()
 # Example 1: Pasadena, California in January (mid-latitude winter)
 lat, lon = [34.15, -118.14]  # Pasadena coordinates
 date = DateTime(2020, 01, 10)
-timezone = +8  # Pacific Standard Time (UTC+8)
+# `timezone` is the offset added to local time to obtain UTC.
+timezone = +8  # Pacific Standard Time is UTC-8, so add 8 h to get UTC
 diurnal_cycle(lat, lon, date, od, timezone, "Pasadena_January.png")
 nothing # hide
 ```
 ![](Pasadena_January.png)
 
-**Finland in Summer**: At the Arctic Circle, the sun does not set at northern summer solitice, resulting in continuous daylight and non-zero insolation for the 24-hour period. This "midnight sun" phenomenon is visible as the sustained insolation during night hours.
+**Finland in Summer**: At the Arctic Circle, the sun does not set at northern summer solstice, resulting in continuous daylight and non-zero insolation for the 24-hour period. This "midnight sun" phenomenon is visible as the sustained insolation during night hours.
 
 ```@example diurnal
 # Example 2: Rovaniemi, Finland in June (Arctic summer - midnight sun)
 lat, lon = [66.50, 25.73]  # Rovaniemi coordinates (Arctic Circle)
 date = DateTime(2020, 06, 20)  # Summer solstice
-timezone = -3  # Eastern European Summer Time (UTC+3)
+# `timezone` is the offset added to local time to obtain UTC.
+timezone = -3  # Eastern European Summer Time is UTC+3, so subtract 3 h to get UTC
 diurnal_cycle(lat, lon, date, od, timezone, "Finland_June.png")
 nothing # hide
 ```

--- a/docs/src/SolarGeometry.md
+++ b/docs/src/SolarGeometry.md
@@ -5,6 +5,7 @@ This page provides the mathematical formulations used in `Insolation.jl` to calc
 ## Overview
 
 Calculating solar position in the sky and insolation requires a sequence of astronomical computations that determine:
+
 1. The planet's position in its orbit (mean and true anomaly)
 2. The latitude of the subsolar point (declination)
 3. The longitude relative to solar noon (hour angle)
@@ -16,10 +17,13 @@ Calculating solar position in the sky and insolation requires a sequence of astr
 The **mean anomaly** $M$ represents the angular position of a planet in its orbit, assuming uniform circular motion. For an elliptical orbit, this is a convenient starting point for more accurate calculations.
 
 The mean anomaly at current time $t$ is
+
 ```math
 M = \frac{2\pi (t - t_0)}{Y_a} + M_0,
 ```
+
 where we have:
+
 - The time at the epoch (J2000), $t_0$, typically defined as January 1, 2000 at 12:00 Terrestrial Time (TT), corresponding to 11:59 UTC
 - The mean anomaly at the epoch, $M_0$ [radians]
 - The length of the anomalistic year, $Y_a$ (period from perihelion to perihelion) [seconds]
@@ -31,17 +35,24 @@ The mean anomaly increases linearly with time at a rate of $2\pi/Y_a$ radians pe
 The **true anomaly** $A$ is the actual angular position of the planet in its elliptical orbit, measured from perihelion (the point of closest approach to the star). Unlike the mean anomaly, the true anomaly accounts for the planet's varying orbital speed due to Kepler's laws.
 
 The true anomaly is computed from the mean anomaly using a series expansion,
+
 ```math
 A = M + \left( 2e - \frac{1}{4}e^{3} \right) \sin(M) + \frac{5}{4} e^2 \sin(2M) + \frac{13}{12} e^3 \sin(3M) + \mathcal{O}(e^4),
 ```
+
 where $e$ is the orbital eccentricity. This series approximation is accurate to order $e^3$ and is sufficient for Earth's relatively circular orbit ($e \approx 0.017$).
+
+!!! warning "Low-eccentricity approximation"
+    The series error grows rapidly with eccentricity (exceeding a few degrees near $e \approx 0.5$). For highly eccentric orbits, it should be replaced by an exact solution of Kepler's equation (e.g., a Newton–Raphson iteration for the eccentric anomaly). Because the true anomaly feeds the declination, planet-star distance, and equation of time, all of these inherit the same eccentricity limitation.
 
 ## Solar Longitude
 
-The **solar longitude** $L_s$ (also called ecliptic longitude or true longitude) specifies the planet's position along its orbital path relative to vernal equinox. It combines the orbital phase (true anomaly $A$) with the helioecentric longitude of perihelion $\varpi$ (angular distance of perihelion relative to vernal equinox):
+The **solar longitude** $L_s$ (also called ecliptic longitude or true longitude) is the ecliptic longitude of the Sun, measured from the vernal equinox. It combines the orbital phase (true anomaly $A$) with the longitude of perihelion $\varpi$: the Sun's ecliptic longitude at perihelion, measured from the vernal equinox (≈ 283° for present-day Earth):
+
 ```math
 L_s = A + \varpi.
 ```
+
 For Earth, $\varpi$ varies slowly due to precession (period $\sim 21{,}000$ years).
 
 ## Declination
@@ -49,41 +60,59 @@ For Earth, $\varpi$ varies slowly due to precession (period $\sim 21{,}000$ year
 The **solar declination** $\delta$ is the angle between the sun's rays and the equatorial plane, or the latitude of the subsolar point (where the sun is in zenith at solar noon). It determines the subsolar latitude (where the sun is directly overhead at solar noon). The declination varies between $\pm\gamma$ (obliquity) over the course of a year.
 
 The sine of the declination angle is
+
 ```math
 \sin \delta = \sin \gamma \sin L_s,
 ```
+
 where we have:
+
 - The orbital obliquity $\gamma$ (axial tilt) [radians]
 - The solar longitude $L_s$ [radians]
 
 For Earth's current obliquity of $\gamma \approx 23.44°$, the declination ranges from $-23.44°$ (winter solstice) to $+23.44°$ (summer solstice), passing through $0°$ at the equinoxes.
 
-## Equation of Time 
+## Equation of Time
 
 The **equation of time** corrects for the difference between **apparent solar time** (when the sun is actually at its highest point) and **mean solar time** (uniform clock time). This discrepancy arises from two effects:
+
 1. The elliptical orbit causes varying orbital speed (eccentricity effect)
 2. The tilted axis projects the sun's motion onto the equatorial plane (obliquity effect)
 
-The equation-of-time hour angle correction [radians] is
+The equation-of-time hour angle correction [radians] is computed exactly as the difference between the mean longitude $L = M + \varpi$ and the right ascension $\alpha$ of the true Sun,
+
 ```math
-\Delta \eta = -2 e \sin(M) + \tan^2(\gamma/2) \sin(2M+2\varpi),
+\Delta \eta = L - \alpha, \qquad \alpha = \operatorname{atan2}\left(\cos\gamma \, \sin L_s,\; \cos L_s\right),
 ```
-where the first term accounts for orbital eccentricity and the second for axial tilt. This can be converted to a time correction through $\Delta t = \Delta\eta T_d/(2\pi)$, where $T_d$ is the length of the solar day. The equation of time correction can be up to ±16 minutes for Earth, explaining why sundials and clocks disagree throughout the year.
+
+where $L_s = A + \varpi$ is the solar longitude. The right ascension follows from the exact projection of the ecliptic longitude onto the equatorial plane, so the obliquity contribution is valid for any tilt $\gamma$ (including $\gamma > 90°$), while the eccentricity contribution enters through the true anomaly $A$.
+
+For small eccentricity and obliquity this reduces to the familiar perturbative form
+
+```math
+\Delta \eta \approx -2 e \sin(M) + \tan^2(\gamma/2) \sin(2M+2\varpi),
+```
+
+where the first term accounts for orbital eccentricity and the second for axial tilt. The correction can be converted to a time offset through $\Delta t = \Delta\eta T_d/(2\pi)$, where $T_d$ is the length of the solar day. For Earth it reaches roughly ±16 minutes over the year, explaining why sundials and clocks disagree.
 
 ## Hour Angle
 
 The **hour angle** $\eta$ measures the angular distance of the sun from the local meridian (north-south line). It quantifies how far past (or before) solar noon we are at a given location:
+
 - Local solar noon: $\eta = 0$  
-- In the afternoon: $\eta > 0$ 
+- In the afternoon: $\eta > 0$
 - In the morning: $\eta < 0$  
 
 The hour angle is calculated from the time of day, with equation of time correction, and adjusted for longitude:
+
 ```math
 \eta = \left( \eta_\text{uncorrected} + \Delta\eta \right) + \lambda,
 ```
+
 where we have:
+
 - The uncorrected hour angle at the prime meridian (0° longitude), $\eta_\text{uncorrected} = 2\pi t_\text{day}$ [radians]
-- The fractional time of day at the prime meridian(0 at midnight, 0.5 at noon), $t_\text{day}$ [dimensionless]
+- The fractional time of day at the prime meridian (0 at midnight, 0.5 at noon), $t_\text{day}$ [dimensionless]
 - The equation of time hour angle correction, $\Delta\eta$ [radians]
 - The longitude $\lambda$ [radians]
 
@@ -92,15 +121,19 @@ All terms are taken modulo $2\pi$ for proper angle wrapping. The factor $2\pi$ c
 ## Zenith Angle
 
 The **zenith angle** $\theta$ is the angle between the sun's rays and the vertical direction (zenith) at a location. It determines how directly sunlight strikes a surface:
-- Sun directly overhead (zenith): $\theta = 0°$ 
-- Sun at the horizon (sunrise/sunset): $\theta = 90°$ 
-- Sun below the horizon (night): $\theta > 90°$ 
+
+- Sun directly overhead (zenith): $\theta = 0°$
+- Sun at the horizon (sunrise/sunset): $\theta = 90°$
+- Sun below the horizon (night): $\theta > 90°$
 
 The cosine of the zenith angle is
+
 ```math
 \cos \theta = \cos \phi \cos \delta \cos \eta + \sin \phi \sin \delta,
 ```
+
 where we have:
+
 - The latitude, $\phi$ [radians], positive northward
 - The solar declination angle, $\delta$ [radians]
 - The hour angle, $\eta$ [radians]
@@ -110,13 +143,16 @@ This is a fundamental equation in solar geometry. The incident solar radiation i
 ## Sunrise/Sunset Angle
 
 The **sunrise/sunset hour angle** $\eta_d$ is the hour angle at which the sun crosses the horizon. It determines the length of day and night:
+
 - Day length = $2\eta_d$ (in radians, or multiply by $T_d/(2\pi)$ for seconds)
 - If $|\tan \phi \tan \delta| > 1$: polar day ($\eta_d = \pi$) or polar night ($\eta_d = 0$)
 
 The sunrise/sunset hour angle is given by
+
 ```math
 \cos \eta_d = - \tan \phi \tan \delta,
 ```
+
 where this equation comes from setting $\theta = 90°$ (sun at horizon) in the zenith angle formula. The negative sign reflects that sunrise occurs at negative hour angles and sunset at positive hour angles.
 
 ## Diurnally Averaged Insolation
@@ -124,30 +160,36 @@ where this equation comes from setting $\theta = 90°$ (sun at horizon) in the z
 The **diurnally averaged** (daily-mean) insolation requires averaging $\cos \theta$ over a full 24-hour period. This is helpful for conceptual models and simpler climate models that do not resolve the full diurnal cycle.
 
 Since insolation is proportional to $\cos \theta$, we need $\overline{\cos \theta}$, the time-averaged cosine of the zenith angle. This can be computed analytically from the sunrise/sunset hour angle:
+
 ```math
 \overline{\cos \theta} = \frac{1}{\pi} \left( \eta_d \sin \phi \sin \delta + \cos \phi \cos \delta \sin \eta_d \right).
 ```
 
 **Physical interpretation:**
-- The $1/\pi$ factor normalizes the average over the daylight period
+
+- The $1/\pi$ prefactor combines the $1/(2\pi)$ average over the full 24-hour day with a factor of 2 from the symmetric sunrise-to-sunset integration limits ($\pm\eta_d$)
 - When $\eta_d = 0$ (polar night), $\overline{\cos \theta} = 0$ (no insolation)
-- When $\eta_d = \pi$ (polar day), $\overline{\cos \theta} = \sin \phi \sin \delta$ (24-hour average)
-- At the equator ($\phi = 0$) during equinox ($\delta = 0$), the formula reduces to $(2/\pi) \cos \phi \cos \delta = 2/\pi \approx 0.637$
+- When $\eta_d = \pi$ (polar day), $\overline{\cos \theta} = \sin \phi \sin \delta$ (24-hour average of the noon-and-midnight sun)
+- At the equator ($\phi = 0$) during equinox ($\delta = 0$), we have $\eta_d = \pi/2$ and the formula reduces to $(1/\pi) \cos \phi \cos \delta \sin \eta_d = 1/\pi \approx 0.318$
 
 ## Azimuth Angle
 
-The **azimuth angle** $\zeta$ specifies the compass direction to the sun, measured from north. It is essential for tracking solar panels, understanding shading, and computing radiation on tilted surfaces.
+The **azimuth angle** $\zeta$ specifies the horizontal direction to the sun. It is essential for tracking solar panels, understanding shading, and computing radiation on tilted surfaces. Note that this package uses a non-standard convention, measuring $\zeta$ from due East and increasing counter-clockwise (see below), rather than the more common convention of measuring clockwise from due North.
 
 The azimuth angle is
+
 ```math
-\zeta = \frac{3\pi}{2} - \arctan \left( \frac{\sin \eta}{\cos \eta \sin \phi - \tan \delta \cos \phi} \right).
+\zeta = \frac{3\pi}{2} - \operatorname{atan2}\left( \cos\delta \sin \eta,\; \cos\delta \cos \eta \sin \phi - \sin\delta \cos \phi \right),
 ```
 
+where the two-argument arctangent ($\operatorname{atan2}$) resolves the correct quadrant. The numerator and denominator are written with a common factor of $\cos\delta \ge 0$ (rather than the more familiar $\sin\eta / (\cos\eta\sin\phi - \tan\delta\cos\phi)$) to avoid the $\tan\delta$ singularity at high declinations.
+
 **Convention in this package:**
-- Sun due **East**: $\zeta = 0$ (or $2\pi$) 
-- Sun due **North**: $\zeta = \pi/2$ 
+
+- Sun due **East**: $\zeta = 0$ (or $2\pi$)
+- Sun due **North**: $\zeta = \pi/2$
 - Sun due **West**: $\zeta = \pi$
-- Sun due **South**: $\zeta = 3\pi/2$ 
+- Sun due **South**: $\zeta = 3\pi/2$
 
 The azimuth increases counter-clockwise when viewed from above. At local solar noon ($\eta = 0$), the sun is due south in the Northern Hemisphere ($\zeta = 3\pi/2$) or due north in the Southern Hemisphere.
 
@@ -156,20 +198,25 @@ The azimuth increases counter-clockwise when viewed from above. At local solar n
 The **planet-star distance** $d$ varies throughout the year due to the elliptical orbit. This variation affects the solar flux received at the top of atmosphere through the inverse square law ($S \propto 1/d^2$).
 
 The distance is calculated from the equation for the orbital ellipse:
+
 ```math
 d = \frac{1-e^2}{1+e\cos A} d_0,
 ```
+
 where we have:
+
 - The orbital eccentricity $e$ (0 for circular, $0<e<1$ for elliptical) [unitless]
 - The true anomaly $A$ [radians]
-- The semi-major axis $d_0$ (mean planet-star distance) [meters]
+- The semi-major axis $d_0$, i.e., the mean planet-star distance
+
+Since the insolation depends only on the *ratio* $d/d_0$ (the inverse-square law gives $S = S_0 (d_0/d)^2$ with $S_0$ the irradiance at the mean distance), `Insolation.jl` works with the dimensionless distance $d/d_0 = (1-e^2)/(1+e\cos A)$ and never needs the absolute orbit size. The returned distance is therefore expressed in units of the semi-major axis.
 
 **For Earth:**
-- Semi-major axis $d_0 = 1$ AU $\approx 1.496 \times 10^{11}$ m
+
 - Eccentricity $e \approx 0.0167$ (current value, varies over millennia)
-- Perihelion (closest): $d \approx 0.983$ AU (early January)
-- Aphelion (farthest): $d \approx 1.017$ AU (early July)
+- Perihelion (closest): $d/d_0 \approx 0.983$ (early January)
+- Aphelion (farthest): $d/d_0 \approx 1.017$ (early July)
 - The $\pm 1.7\%$ variation in distance causes a $\pm 3.4\%$ variation in solar flux
+- The semi-major axis is $d_0 \approx 1.496 \times 10^{11}$ m $= 1$ AU; multiply $d/d_0$ by this to recover a physical distance
 
 Earth is closest to the sun during Northern Hemisphere winter, but the obliquity effect dominates over the distance effect in determining seasons.
-

--- a/docs/src/find_equinox_perihelion_dates.jl
+++ b/docs/src/find_equinox_perihelion_dates.jl
@@ -13,7 +13,7 @@ function zdiff(x, year, od)
     date = xtomarchdate(x, year)
 
     # Get orbital parameters for this time
-    Δt_years = Insolation.years_since_epoch(param_set, date)
+    Δt_years = Insolation.julian_years_since_epoch(param_set, date)
     orb_params = Insolation.orbital_params(od, Δt_years)
 
     # Calculate zenith angles for Southern and Northern mid-latitudes
@@ -35,13 +35,13 @@ function edist(x, year, od)
     date = xtojandate(x, year)
 
     # Get orbital parameters for this time
-    Δt_years = Insolation.years_since_epoch(param_set, date)
+    Δt_years = Insolation.julian_years_since_epoch(param_set, date)
     orb_params = Insolation.orbital_params(od, Δt_years)
 
-    # Calculate distance
+    # Calculate distance (already in units of the semi-major axis)
     result = Insolation.daily_distance_zenith_angle(date, 0.0, orb_params, param_set)
 
-    return result.d / IP.orbit_semimaj(param_set)
+    return result.d
 end
 
 # x is date relative to Jan 1, with 1.00 representing Jan 1 00:00

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -18,7 +18,9 @@ The package provides functions organized into three main categories:
 
 ### Parameter Structures
 
-**`InsolationParameters{FT}`** - The main parameter struct containing physical and orbital constants needed for insolation calculations. See the source code or API documentation for all fields.
+```@docs
+Insolation.InsolationParameters
+```
 
 ### Parameter Creation
 
@@ -42,13 +44,12 @@ using Insolation.Parameters
 params = InsolationParameters{Float64}(
     year_anom = 365.259636 * 86400.0,
     day = 86400.0,
-    orbit_semimaj = 1.496e11,
-    eccentricity_epoch = 0.0167,
-    obliq_epoch = deg2rad(23.44),
-    lon_perihelion_epoch = deg2rad(282.95),
+    eccentricity_epoch = 0.016708634,
+    obliq_epoch = deg2rad(23.43278),
+    lon_perihelion_epoch = deg2rad(282.9373),
     tot_solar_irrad = 1362.0,
-    epoch = DateTime(2000, 1, 1, 12, 0, 0),
-    mean_anom_epoch = deg2rad(357.5291)
+    epoch = DateTime(2000, 1, 1, 11, 58, 55, 816),
+    mean_anom_epoch = deg2rad(357.52911)
 )
 ```
 
@@ -128,6 +129,7 @@ Insolation.equation_of_time
 ```@docs
 Insolation.planet_star_distance
 Insolation.years_since_epoch
+Insolation.julian_years_since_epoch
 Insolation.distance_declination_mean_anomaly
 ```
 

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -69,9 +69,8 @@ The following ClimaParams names are mapped to Insolation.jl fields:
 - `epoch_time` → `epoch`: Reference epoch (DateTime)
 - `day` → `day`: Length of solar day [s]
 - `anomalistic_year_length` → `year_anom`: Anomalistic year length [s]
-- `length_orbit_semi_major` → `orbit_semimaj`: Orbital semi-major axis [m]
 - `orbit_eccentricity_at_epoch` → `eccentricity_epoch`: Eccentricity at epoch
-- `total_solar_irradiance` → `tot_solar_irrad`: Solar irradiance at 1 AU [W m⁻²]
+- `total_solar_irradiance` → `tot_solar_irrad`: Solar irradiance at the mean orbital distance [W m⁻²]
 - `orbit_obliquity_at_epoch` → `obliq_epoch`: Obliquity at epoch [rad]
 - `mean_anomaly_at_epoch` → `mean_anom_epoch`: Mean anomaly at epoch [rad]
 - `longitude_perihelion_at_epoch` → `lon_perihelion_epoch`: Longitude of perihelion at epoch [rad]
@@ -97,7 +96,6 @@ function InsolationParameters(
         :epoch_time => :epoch,
         :day => :day,
         :anomalistic_year_length => :year_anom,
-        :length_orbit_semi_major => :orbit_semimaj,
         :orbit_eccentricity_at_epoch => :eccentricity_epoch,
         :total_solar_irradiance => :tot_solar_irrad,
         :orbit_obliquity_at_epoch => :obliq_epoch,

--- a/src/Insolation.jl
+++ b/src/Insolation.jl
@@ -35,13 +35,24 @@ export InsolationParameters
     OrbitalDataSplines
 
 A container struct that holds cubic spline interpolators for Earth's
-orbital parameters, based on the Laskar 2004 dataset.
+orbital parameters, based on the Laskar et al. (2004) dataset.
 
-The time series of orbital parameters are lazily downloaded from the 
-`orbital_parameters_dataset_path(artifact_dir)` path where `artifact_dir` is 
-the path and filename to save the artifacts toml file.
+The orbital parameter time series is loaded from the `laskar2004` artifact,
+which is downloaded lazily on first use. The splines are functions of time in
+Julian years since the J2000 epoch (see [`julian_years_since_epoch`](@ref)).
 
-The splines are functions of time (in years since J2000 epoch).
+!!! warning "Earth-specific"
+    The Laskar et al. (2004) solution describes the orbital history of **Earth**.
+    Enabling Milankovitch cycles (`milankovitch = true`) with these splines for
+    another planet would silently apply Earth's orbital variations to it, so the
+    time-varying orbital parameters are meaningful for Earth only. Fixed,
+    user-supplied epoch parameters (`milankovitch = false`) remain valid for any
+    planetary body.
+
+# Fields
+- `e_spline`: Spline for eccentricity [unitless].
+- `γ_spline`: Spline for obliquity [radians].
+- `ϖ_spline`: Spline for longitude of perihelion [radians].
 
 # GPU Support
 This struct is GPU-compatible via Adapt.jl. To transfer to GPU memory:
@@ -91,20 +102,22 @@ Base.broadcastable(x::OrbitalDataSplines) = tuple(x)
 """
     orbital_params(od::OrbitalDataSplines, dt::FT) where {FT <: Real}
 
-Interpolates time-varying orbital parameters using Milankovitch cycles.
+Interpolate the time-varying orbital parameters (Milankovitch cycles).
 
-Interpolates orbital parameters from the Laskar et al. (2004) dataset for
+Interpolate orbital parameters from the Laskar et al. (2004) dataset for
 paleoclimate studies. The parameters vary over geological timescales.
 
 # Arguments
-- `od::OrbitalDataSplines`: The struct containing orbital parameter splines.
-- `dt::FT`: The time for interpolation [Years since J2000 epoch].
+- `od::OrbitalDataSplines`: The struct containing the orbital parameter splines.
+- `dt::FT`: The time for interpolation [Julian years since the J2000 epoch].
 
 # Returns
 - `(ϖ, γ, e)`: A tuple containing:
   - `ϖ`: Longitude of perihelion [radians]
   - `γ`: Obliquity (axial tilt) [radians]
   - `e`: Orbital eccentricity [unitless]
+
+See also the `orbital_params(param_set)` method for the fixed epoch parameters.
 """
 function orbital_params(od::OrbitalDataSplines, dt::FT) where {FT<:Real}
     # Call the spline fields directly
@@ -117,7 +130,7 @@ end
 """
     orbital_params(param_set::AIP)
 
-Returns fixed orbital parameters at epoch.
+Return the fixed orbital parameters at epoch.
 
 Uses the constant orbital parameter values at the reference epoch (typically
 J2000) stored in the parameter set. Suitable for modern climate simulations
@@ -143,17 +156,31 @@ end
     TSIDataSpline
 
 A container struct that holds a cubic interpolator for the monthly mean total
-solar irradiance.
+solar irradiance, from the CMIP record of the Sun's irradiance **at 1 au**.
 
 The spline is a function of date between `1850-01-15T12:00` and
 `2229-12-15T12:00`. Dates outside this range will result in `NaN`.
+
+!!! warning "Earth-specific"
+    The data are the Sun's total solar irradiance at 1 au. When passed to
+    [`insolation`](@ref)/[`daily_insolation`](@ref), the value is used as the
+    irradiance at the planet's *mean orbital distance* (the semi-major axis),
+    which is correct only for Earth, whose semi-major axis is ≈ 1 au. For another
+    body the value would need to be rescaled by `(1 au / semi-major axis)²`, which
+    this package does not do; the spline is therefore meaningful for Earth only.
+    (It is also a fixed historical/projected record of *our* Sun.)
+
+# Fields
+- `tsi_spline`: Spline of total solar irradiance in months since `ref_date` [W m⁻²].
+- `dates`: The monthly dates of the underlying data points.
+- `ref_date`: The reference date corresponding to the first data point.
 
 # GPU Support
 This struct is GPU-compatible via Adapt.jl. To transfer to GPU memory:
 ```julia
 using CUDA, Adapt
 cpu_tsi = TSIDataSpline(Float32)  # Create on CPU
-gpu_tsi = adapt(CuArray, TSIDataSpline)  # Transfer to GPU
+gpu_tsi = adapt(CuArray, cpu_tsi)  # Transfer to GPU
 ```
 """
 struct TSIDataSpline{SPLINE,DATES,DATE<:Dates.DateTime}
@@ -178,7 +205,7 @@ end
 """
     TSIDataSpline(::Type{FT}) where {FT <: AbstractFloat}
 
-Constructs a `TSIDataSpline` that interpolates monthly mean total solar
+Construct a `TSIDataSpline` that interpolates monthly mean total solar
 irradiance as a function of the date and time.
 """
 function TSIDataSpline(::Type{FT}) where {FT<:AbstractFloat}
@@ -194,8 +221,8 @@ end
 """
     evaluate(tsi::TSIDataSpline, date::Dates.DateTime)
 
-Interpolate monthly mean total solar irradiance at `date` via a cubic
-interpolation.
+Interpolate the monthly mean total solar irradiance at `date` (the Sun's
+irradiance at 1 au) via a cubic interpolation.
 
 The spline is a function of date between `1850-01-15T12:00` and
 `2229-12-15T12:00`. Dates outside this range will result in `NaN`.
@@ -208,13 +235,15 @@ function evaluate(tsi::TSIDataSpline, date::Dates.DateTime)
         return NaN
     end
 
-    # There are two cases:
-    # 1. Day and time of month is on or after 12:00 of the 15th
-    # 2. Day and time of month is before 12:00 of the 15th
+    # The data points sit at 12:00 on the 15th of each month, so we locate the
+    # interval [dates[i], dates[i+1]] that contains `date` by identifying the
+    # month whose 15th-at-noon starts that interval. There are two cases:
+    # 1. `date` is on or after 12:00 of the 15th: the interval starts in this month.
+    # 2. `date` is before 12:00 of the 15th: the interval starts in the previous month.
     day_val = Dates.day(date)
     hour_val = Dates.hour(date)
-    if day_val >= 15 && hour_val >= 12
-        # Cover casea 1
+    if day_val > 15 || (day_val == 15 && hour_val >= 12)
+        # Cover case 1
         target_year = Dates.year(date)
         target_month = Dates.month(date)
     else

--- a/src/InsolationCalc.jl
+++ b/src/InsolationCalc.jl
@@ -8,16 +8,27 @@ export insolation, daily_insolation
         solar_variability_spline::Union{TSIDataSpline,Nothing} = nothing,
     ) where {FT<:Real}
 
-Calculates the solar radiative energy flux at the top of the atmosphere
+Calculate the solar radiative energy flux at the top of the atmosphere
 (TOA) based on the planet-star distance and the inverse square law.
 
+The total solar irradiance `S0` (either `tot_solar_irrad` or, if a
+`solar_variability_spline` is supplied, the interpolated value) is defined at the
+*mean* orbital distance (the semi-major axis). Since `d` is the planet-star
+distance in units of the semi-major axis, the flux is simply
+``S = S_0 / d^2``. The absolute size of the orbit does not enter: the flux
+depends only on `S0` and the orbital shape (eccentricity and true anomaly).
+
 # Arguments
-- `d::FT`: Planet-star distance [m]
-- `param_set::IP.AIP`: Struct containing `tot_solar_irrad` [W m⁻²] and `orbit_semimaj` [m]
-- `date::Union{DateTime,Nothing}`: (default `nothing`) Current date and time to evaluate the
-  solar flux if `tsi_spline` is available.
-- `solar_variability_spline::Union{TSIDataSpline,Nothing}`: Use time-varying solar
-  luminosity if `TSIDataSpline` is passed as an argument.
+- `d::FT`: Planet-star distance, in units of the semi-major axis [unitless]
+- `param_set::IP.AIP`: Struct containing `tot_solar_irrad`, the total solar irradiance
+  at the mean orbital distance [W m⁻²]
+- `date::Union{DateTime,Nothing}`: (default `nothing`) Current date and time used to evaluate
+  the solar flux if `solar_variability_spline` is available.
+- `solar_variability_spline::Union{TSIDataSpline,Nothing}`: (default `nothing`) Use time-varying
+  solar luminosity if a `TSIDataSpline` is passed as an argument.
+
+# Returns
+- `S`: Solar flux at the given planet-star distance [W m⁻²]
 """
 function solar_flux(
     d::FT,
@@ -28,29 +39,35 @@ function solar_flux(
     S0::FT =
         isnothing(solar_variability_spline) ? IP.tot_solar_irrad(param_set) :
         FT(evaluate(solar_variability_spline, date))
-    d0::FT = IP.orbit_semimaj(param_set)
 
-    # Solar radiative energy flux
-    S = S0 * (d0 / d)^2
+    # Solar radiative energy flux. `d` is in units of the semi-major axis (the mean
+    # orbital distance at which S0 is defined), so the inverse-square law is S0 / d².
+    S = S0 / d^2
     return S
 end
 
 """
-    insolation(θ::FT, d::FT, param_set::IP.AIP) where {FT <: Real}
+    insolation(
+        θ::FT,
+        d::FT,
+        param_set::IP.AIP,
+        date::Union{DateTime,Nothing} = nothing,
+        solar_variability_spline::Union{TSIDataSpline,Nothing} = nothing,
+    ) where {FT <: Real}
 
-Calculates top-of-atmosphere (TOA) insolation and cosine of solar zenith angle.
+Calculate top-of-atmosphere (TOA) insolation and the cosine of the solar zenith angle.
 
 Implements ``F = S \\cos(\\theta)`` where S is the solar flux at the given
 planet-star distance. Insolation is set to 0 at night (when ``\\cos(\\theta) < 0``).
 
 # Arguments
 - `θ::FT`: Solar zenith angle [radians]
-- `d::FT`: Planet-star distance [m]
+- `d::FT`: Planet-star distance, in units of the semi-major axis [unitless]
 - `param_set::IP.AIP`: Parameter struct
-- `date::Union{DateTime,Nothing}`: (default `nothing`) Current date and time to evaluate the
-  solar flux if `tsi_spline` is available.
-- `solar_variability_spline::Union{TSIDataSpline,Nothing}`: Use time-varying solar luminosity if
-  `TSIDataSpline` is passed as an argument.
+- `date::Union{DateTime,Nothing}`: (default `nothing`) Current date and time used to evaluate the
+  solar flux if `solar_variability_spline` is available.
+- `solar_variability_spline::Union{TSIDataSpline,Nothing}`: (default `nothing`) Use time-varying
+  solar luminosity if a `TSIDataSpline` is passed as an argument.
 
 # Returns
 A `NamedTuple` with fields:
@@ -89,7 +106,7 @@ end
         eot_correction::Bool = true,
     ) where {FT1 <: Real, FT2 <: Real}
 
-Calculates instantaneous TOA insolation with optional long-term variations
+Calculate instantaneous TOA insolation with optional long-term variations
 in Earth's orbital parameters (Milankovitch cycles) and solar luminosity.
 
 # Arguments
@@ -99,9 +116,11 @@ in Earth's orbital parameters (Milankovitch cycles) and solar luminosity.
 - `param_set::IP.AIP`: Parameter struct
 - `orbital_data::Union{OrbitalDataSplines, Nothing}`: (default nothing) Orbital parameter splines.
   **Required** when `milankovitch=true` for GPU compatibility.
-- `milankovitch::Bool`: (default false) Use time-varying orbital parameters (Milankovitch cycles)
+- `milankovitch::Bool`: (default false) Use time-varying orbital parameters (Milankovitch cycles).
+  The `OrbitalDataSplines` are Earth-specific (Laskar et al., 2004), so this is meaningful for Earth only.
 - `solar_variability_spline::Union{TSIDataSpline, Nothing}`: (default nothing) Use time-varying
-  solar luminosity if `TSIDataSpline` is passed as an argument.
+  solar luminosity if `TSIDataSpline` is passed as an argument. The `TSIDataSpline` gives the
+  Sun's irradiance at 1 au, so this is meaningful for Earth only.
 - `eot_correction::Bool`: (default true) Apply equation of time correction
 
 # Returns
@@ -122,11 +141,14 @@ milankovitch = true
 (; F, S, μ, ζ) = insolation(date, lat, lon, param_set, od, milankovitch)
 
 # Without equation of time correction
-milankovitch = false,
+orbital_data = nothing
+milankovitch = false
 solar_variability_spline = nothing
 eot_correction = false
-result = insolation(date, lat, lon, param_set, milankovitch, solar_variability_spline, eot_correction)
+result = insolation(date, lat, lon, param_set, orbital_data, milankovitch, solar_variability_spline, eot_correction)
 ```
+
+See also [`daily_insolation`](@ref) and [`solar_geometry`](@ref).
 
 # GPU Usage
 For GPU execution, create orbital and solar variability data on CPU and transfer
@@ -187,19 +209,21 @@ end
         solar_variability_spline::Union{TSIDataSpline, Nothing} = nothing,
     )
 
-Calculates diurnally averaged TOA insolation with optional long-term variations
-in orbital parameters (Milankovitch cycles) and solar luminosity. The insolation is 
+Calculate diurnally averaged TOA insolation with optional long-term variations
+in orbital parameters (Milankovitch cycles) and solar luminosity. The insolation is
 averaged over a full day.
 
 # Arguments
 - `date::DateTime`: Current date
-- `latitude::FT`: Latitude [degrees]
+- `latitude::Real`: Latitude [degrees]
 - `param_set::IP.AIP`: Parameter struct
 - `orbital_data::Union{OrbitalDataSplines, Nothing}`: (default nothing) Orbital parameter splines.
   **Required** when `milankovitch=true` for GPU compatibility.
 - `milankovitch::Bool`: (default false) Use time-varying orbital parameters (Milankovitch cycles).
+  The `OrbitalDataSplines` are Earth-specific (Laskar et al., 2004), so this is meaningful for Earth only.
 - `solar_variability_spline::Union{TSIDataSpline, Nothing}`: (default nothing) Use time-varying
-  solar luminosity if `TSIDataSpline` is passed as an argument.
+  solar luminosity if `TSIDataSpline` is passed as an argument. The `TSIDataSpline` gives the
+  Sun's irradiance at 1 au, so this is meaningful for Earth only.
 
 # Returns
 A `NamedTuple` with fields:
@@ -215,8 +239,11 @@ result = daily_insolation(date, lat, param_set)
 
 # Paleoclimate with Milankovitch cycles
 od = OrbitalDataSplines()  # Load once
-result = daily_insolation(date, lat, param_set, od; milankovitch=true)
+milankovitch = true
+result = daily_insolation(date, lat, param_set, od, milankovitch)
 ```
+
+See also [`insolation`](@ref).
 
 # GPU Usage
 For GPU execution, create orbital and solar variability data on CPU and transfer
@@ -250,12 +277,9 @@ function daily_insolation(
     )
 
     # Get effective zenith angle and distance for daily averaged insolation
-    (; daily_θ, d) = Insolation.daily_distance_zenith_angle(
-        date,
-        eltype(param_set)(latitude),
-        orb_params,
-        param_set,
-    )
+    # (daily_distance_zenith_angle converts inputs to eltype(param_set) internally)
+    (; daily_θ, d) =
+        Insolation.daily_distance_zenith_angle(date, latitude, orb_params, param_set)
 
     # Return daily averaged insolation
     return insolation(daily_θ, d, param_set, date, solar_variability_spline)
@@ -300,10 +324,11 @@ function get_orbital_parameters(
                 "Spline interpolator orbital_data must be provided when milankovitch=true for GPU compatibility.\n
                 Load OrbitalDataSplines: od = OrbitalDataSplines();\n
                 Transfer to GPU: gpu_od = adapt(CuArray, od);\n
-                Then call: insolation(date, lat, lon, param_set, gpu_od; milankovitch=true)\n",
+                Then call: insolation(date, lat, lon, param_set, gpu_od, true)\n",
             )
         end
-        Δt_years = Insolation.years_since_epoch(param_set, date)
+        # The Laskar (2004) tables are indexed in Julian years since J2000
+        Δt_years = Insolation.julian_years_since_epoch(param_set, date)
         ϖ, γ, e = Insolation.orbital_params(orbital_data, Δt_years)
     else
         # Compute epoch parameters

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -17,6 +17,30 @@ const AIP = AbstractInsolationParams
 
 import Dates: DateTime
 
+"""
+    InsolationParameters{FT}
+
+The orbital, solar, and epoch parameters needed for insolation calculations.
+
+This is the main concrete subtype of [`AbstractInsolationParams`](@ref). It can be
+constructed directly with the keyword constructor (see the fields below), or, when
+`ClimaParams.jl` is loaded, with the convenience constructor `InsolationParameters(FT)`,
+which fills in default values for modern Earth.
+
+The values stored here describe the planet's orbit at a fixed reference epoch (typically
+J2000); time-varying (Milankovitch) orbital parameters are supplied separately through
+[`Insolation.OrbitalDataSplines`](@ref).
+
+# Fields
+- `year_anom`: Anomalistic year (perihelion to perihelion) [seconds].
+- `day`: Length of a solar day [seconds].
+- `eccentricity_epoch`: Eccentricity at epoch [unitless].
+- `obliq_epoch`: Obliquity (axial tilt) at epoch [radians].
+- `lon_perihelion_epoch`: Longitude of perihelion at epoch [radians].
+- `tot_solar_irrad`: Total solar irradiance at the mean orbital distance (semi-major axis) [W m⁻²].
+- `epoch`: Reference epoch time [`DateTime`].
+- `mean_anom_epoch`: Mean anomaly at epoch [radians].
+"""
 Base.@kwdef struct InsolationParameters{FT} <: AbstractInsolationParams
     # Orbital periods
     "Anomalistic year (perihelion to perihelion) [seconds]"
@@ -25,8 +49,6 @@ Base.@kwdef struct InsolationParameters{FT} <: AbstractInsolationParams
     day::FT
 
     # Orbital geometry
-    "Orbit semi-major axis (mean planet-star distance) [m]"
-    orbit_semimaj::FT
     "Eccentricity at epoch [unitless]"
     eccentricity_epoch::FT
     "Obliquity at epoch [radians]"
@@ -35,7 +57,7 @@ Base.@kwdef struct InsolationParameters{FT} <: AbstractInsolationParams
     lon_perihelion_epoch::FT
 
     # Solar and Epoch parameters
-    "Total Solar Irradiance at 1 au [W m⁻²]"
+    "Total solar irradiance at the mean orbital distance (semi-major axis) [W m⁻²]"
     tot_solar_irrad::FT
     "Reference epoch time [DateTime]"
     epoch::DateTime

--- a/src/SolarGeometry.jl
+++ b/src/SolarGeometry.jl
@@ -3,13 +3,13 @@ export solar_geometry, daily_distance_zenith_angle
 """
     mean_anomaly(Δt_years::FT, param_set::IP.AIP) where {FT}
 
-Calculates the mean anomaly at a given time since epoch.
+Calculate the mean anomaly at a given time since epoch.
 
 The mean anomaly is the angle the planet would have traveled from perihelion
 if it moved in a circular orbit at constant angular velocity.
 
 # Arguments
-- `Δt_years::FT`: Time since epoch [years]
+- `Δt_years::FT`: Time since epoch [anomalistic years]
 - `param_set::IP.AIP`: Parameter struct containing `mean_anom_epoch`
 
 # Returns
@@ -24,11 +24,20 @@ end
 """
     true_anomaly(MA::FT, e::FT) where {FT <: Real}
 
-Calculates the true anomaly from the mean anomaly.
+Calculate the true anomaly from the mean anomaly.
 
 The true anomaly is the actual angular distance of the planet from perihelion
-along its orbital path. This function uses a series expansion accurate to
-O(e⁴) where e is the eccentricity (see Fitzpatrick (2012), Appendix A.10).
+along its orbital path. This function uses a series expansion (the "equation of
+the center") that is accurate to third order in the eccentricity `e`, with an
+error of O(e⁴) (see Fitzpatrick (2012), Appendix A.10).
+
+!!! warning "Low-eccentricity approximation"
+    The series is intended for nearly circular orbits such as Earth's
+    (`e ≈ 0.0167`). Its error grows rapidly with eccentricity (exceeding a few
+    degrees near `e ≈ 0.5`), so for highly eccentric orbits it should be replaced
+    by an exact solution of Kepler's equation (e.g., a Newton–Raphson iteration
+    for the eccentric anomaly). This approximation affects every quantity derived
+    from the true anomaly (declination, distance, and the equation of time).
 
 # Arguments
 - `MA::FT`: Mean anomaly [radians]
@@ -50,10 +59,10 @@ end
 """
     solar_longitude(TA::FT, ϖ::FT) where {FT <: Real}
 
-Calculates the solar longitude (ecliptic longitude of the Sun).
+Calculate the solar longitude (ecliptic longitude of the Sun).
 
-The solar longitude is the angular distance of the planet along its orbital 
-path, measured from vernal equinox. It is the sum of the true anomaly 
+The solar longitude is the angular distance of the planet along its orbital
+path, measured from the vernal equinox. It is the sum of the true anomaly
 (angle from perihelion) and the longitude of perihelion.
 
 # Arguments
@@ -77,7 +86,7 @@ end
         eot_correction::Bool = true,
     ) where {FT}
 
-Calculates the hour angle at a given time and longitude.
+Calculate the hour angle at a given time and longitude.
 
 The hour angle is zero at local solar noon and increases with time.
 Optionally applies the equation of time correction to account for 
@@ -119,14 +128,23 @@ end
 """
     equation_of_time(MA::FT, (ϖ, γ, e)::Tuple{FT, FT, FT}) where {FT <: Real}
 
-Calculates the equation of time correction for the hour angle.
+Calculate the equation of time correction for the hour angle.
 
-The equation of time accounts for the difference between apparent solar time 
-(based on the actual Sun's position in the sky) and mean solar time (based on 
-a fictitious mean Sun moving at constant speed). This difference arises from 
+The equation of time accounts for the difference between apparent solar time
+(based on the actual Sun's position in the sky) and mean solar time (based on
+a fictitious mean Sun moving at constant speed). This difference arises from
 two effects:
-1. Earth's elliptical orbit (eccentricity e)
-2. Earth's axial tilt (obliquity γ)
+1. The elliptical orbit (eccentricity e)
+2. The axial tilt (obliquity γ)
+
+It is computed as the difference between the mean longitude ``L = M + \\varpi``
+and the right ascension ``\\alpha`` of the true Sun. The right ascension is
+obtained from the exact projection of the ecliptic longitude onto the equatorial
+plane, ``\\alpha = \\mathrm{atan2}(\\cos\\gamma \\sin L_s, \\cos L_s)`` with
+``L_s`` the solar longitude, so the obliquity contribution is exact for any
+``\\gamma`` (it does not rely on a small-tilt expansion). The eccentricity
+contribution enters through the true anomaly and is therefore accurate to the
+same order in `e` as [`true_anomaly`](@ref).
 
 # Arguments
 - `MA::FT`: Mean anomaly [radians]
@@ -139,31 +157,40 @@ two effects:
 - `Δη`: Hour angle correction [radians]
 """
 function equation_of_time(MA::FT, (ϖ, γ, e)::Tuple{FT,FT,FT}) where {FT<:Real}
-    Δη = -2 * e * sin(MA) + tan(γ / 2)^2 * sin(2 * (MA + ϖ))
+    # Mean longitude of the fictitious mean Sun and true ecliptic (solar) longitude
+    L = MA + ϖ
+    L_s = true_anomaly(MA, e) + ϖ
+    # Right ascension of the true Sun from the exact equatorial projection (valid
+    # for any obliquity γ, including γ > π/2)
+    α = atan(cos(γ) * sin(L_s), cos(L_s))
+    # Equation of time as an hour-angle correction: mean longitude − right ascension
+    Δη = L - α
     return mod(Δη + FT(π), FT(2π)) - FT(π)
 end
 
 """
-    planet_star_distance(TA::FT, e::FT, param_set::IP.AIP) where {FT <: Real}
+    planet_star_distance(TA::FT, e::FT) where {FT <: Real}
 
-Calculates the distance between planet (Earth) and star (Sun) at a given 
-true anomaly.
+Calculate the planet-star distance at a given true anomaly, in units of the
+semi-major axis (the mean orbital distance).
 
 The distance varies due to the planet's elliptical orbit, being shortest at
 perihelion and longest at aphelion. The calculation uses the orbit equation
-for an ellipse.
+for an ellipse. The result is normalized by the semi-major axis ``a``, so it is
+the dimensionless ratio ``d/a = (1-e^2)/(1+e\\cos A)``, which ranges from `1-e`
+(perihelion) to `1+e` (aphelion). The absolute orbit size is irrelevant to the
+insolation, so it is not carried; multiply by the semi-major axis to recover a
+physical distance.
 
 # Arguments
 - `TA::FT`: True anomaly [radians]
 - `e::FT`: Orbital eccentricity [unitless]
-- `param_set::IP.AIP`: Parameter struct containing `orbit_semimaj`
 
 # Returns
-- `d`: Planet-star distance [m]
+- `d`: Planet-star distance, in units of the semi-major axis [unitless]
 """
-function planet_star_distance(TA::FT, e::FT, param_set::IP.AIP) where {FT<:Real}
-    d0 = IP.orbit_semimaj(param_set)
-    d = d0 * (1 - e^2) / (1 + e * cos(TA))
+function planet_star_distance(TA::FT, e::FT) where {FT<:Real}
+    d = (1 - e^2) / (1 + e * cos(TA))
     return d
 end
 
@@ -173,7 +200,7 @@ end
         date::DateTime,
     ) where {FT}
 
-Calculates the time elapsed since epoch (typically J2000) in anomalistic 
+Calculate the time elapsed since epoch (typically J2000) in anomalistic
 years (the time from perihelion to perihelion).
 
 Converts the time difference between two dates from Julian days to
@@ -185,6 +212,9 @@ anomalistic years, which is the natural time unit for orbital calculations.
 
 # Returns
 - `Δt_years`: Time since epoch [anomalistic years]
+
+See also [`julian_years_since_epoch`](@ref), which uses Julian years (the time unit
+of the Laskar et al. (2004) orbital tables).
 """
 function years_since_epoch(
     param_set::IP.InsolationParameters{FT},
@@ -196,13 +226,44 @@ function years_since_epoch(
 end
 
 """
+    julian_years_since_epoch(
+        param_set::IP.InsolationParameters{FT},
+        date::DateTime,
+    ) where {FT}
+
+Calculate the time elapsed since epoch (typically J2000) in Julian years
+(a Julian year is exactly 365.25 days of 86400 s each).
+
+This is the time unit of the Laskar et al. (2004) orbital-parameter tables, so it
+is used to index [`OrbitalDataSplines`](@ref). It differs slightly from
+[`years_since_epoch`](@ref), which returns *anomalistic* years (the natural unit
+for the mean anomaly); the two differ by the ratio of the anomalistic year to the
+Julian year (~0.0026% for Earth).
+
+# Arguments
+- `param_set::IP.InsolationParameters{FT}`: Parameter struct
+- `date::DateTime`: Current date and time
+
+# Returns
+- `Δt_years`: Time since epoch [Julian years]
+"""
+function julian_years_since_epoch(
+    param_set::IP.InsolationParameters{FT},
+    date::DateTime,
+) where {FT}
+    epoch = IP.epoch(param_set)
+    days_per_julian_year = FT(365.25)
+    return FT(datetime2julian(date) - datetime2julian(epoch)) / days_per_julian_year
+end
+
+"""
     distance_declination_mean_anomaly(
         Δt_years::FT,
         (ϖ, γ, e)::Tuple{FT, FT, FT},
         param_set::IP.AIP,
     ) where {FT}
 
-Computes planet-star distance, solar declination angle, and mean anomaly.
+Compute the planet-star distance, solar declination angle, and mean anomaly.
 
 This function calculates key astronomical parameters from orbital elements.
 The declination determines the subsolar latitude, while the planet-star distance
@@ -218,7 +279,7 @@ hour angle calculations.
 - `param_set::IP.AIP`: Parameter struct
 
 # Returns
-- `d`: Planet-star distance [m]
+- `d`: Planet-star distance, in units of the semi-major axis [unitless]
 - `δ`: Solar declination angle [radians]
 - `MA`: Mean anomaly [radians]
 """
@@ -236,11 +297,11 @@ function distance_declination_mean_anomaly(
     # Solar longitude [radians]
     SL = solar_longitude(TA, ϖ)
 
-    # Declination angle [radians]
-    δ = mod(asin(sin(γ) * sin(SL)), FT(2π))
+    # Declination angle [radians], in [-π/2, π/2]
+    δ = asin(sin(γ) * sin(SL))
 
-    # Planet-star distance [m] 
-    d = planet_star_distance(TA, e, param_set)
+    # Planet-star distance, in units of the semi-major axis
+    d = planet_star_distance(TA, e)
 
     return d, δ, MA
 end
@@ -250,22 +311,25 @@ end
         date::DateTime,
         latitude::Real,
         longitude::Real,
-        (ϖ, γ, e)::Tuple{FT, FT, FT},
+        orb_params::Tuple{<:Real, <:Real, <:Real},
         param_set::AIP;
         eot_correction::Bool = true,
-    ) where {FT}
+    )
 
-Calculates planet-star distance, solar zenith angle, and azimuthal angle.
+Calculate the planet-star distance, solar zenith angle, and azimuth angle.
 
 This is a high-level function that combines all necessary astronomical
-calculations to determine the planet's position and distance from the star
-at a specific time and location.
+calculations to determine the position of the star in the sky (zenith and
+azimuth angles) and the planet-star distance at a specific time and location.
+
+All real-valued inputs are converted to `eltype(param_set)` internally, so the
+computation is carried out consistently in the parameter set's floating-point type.
 
 # Arguments
 - `date::DateTime`: Current date and time
 - `latitude::Real`: Latitude [degrees]
 - `longitude::Real`: Longitude [degrees]
-- `(ϖ, γ, e)::Tuple{FT, FT, FT}`: Orbital parameters tuple containing:
+- `orb_params::Tuple{<:Real, <:Real, <:Real}`: Orbital parameters tuple `(ϖ, γ, e)`:
   - `ϖ`: Longitude of perihelion [radians]
   - `γ`: Obliquity (axial tilt) [radians]
   - `e`: Orbital eccentricity [unitless]
@@ -274,7 +338,7 @@ at a specific time and location.
 
 # Returns
 A `NamedTuple` with fields:
-- `d`: Planet-Sun distance [m]
+- `d`: Planet-Sun distance, in units of the semi-major axis [unitless]
 - `θ`: Solar zenith angle [radians]
 - `ζ`: Solar azimuth angle [radians], 0 = due East, increasing CCW
 """
@@ -282,12 +346,15 @@ function solar_geometry(
     date::DateTime,
     latitude::Real,
     longitude::Real,
-    (ϖ, γ, e)::Tuple{FT,FT,FT},
+    orb_params::Tuple{<:Real,<:Real,<:Real},
     param_set::AIP;
     eot_correction = true,
-) where {FT}
-    ϕ = eltype(param_set)(deg2rad(latitude))
-    λ = eltype(param_set)(deg2rad(longitude))
+)
+    FT = eltype(param_set)
+    # Convert all inputs to the parameter set's float type for type consistency
+    ϖ, γ, e = FT.(orb_params)
+    ϕ = FT(deg2rad(latitude))
+    λ = FT(deg2rad(longitude))
 
     # Get time since epoch in anomalistic years
     Δt_years = years_since_epoch(param_set, date)
@@ -298,15 +365,18 @@ function solar_geometry(
     # Get hour angle at given longitude
     η = hour_angle(date, λ, MA, (ϖ, γ, e); eot_correction)
 
-    # Solar zenith angle [radians]
-    θ = mod(
-        acos(max(FT(-1), min(FT(1), cos(ϕ) * cos(δ) * cos(η) + sin(ϕ) * sin(δ)))),
-        FT(2π),
-    )
+    # Solar zenith angle [radians], in [0, π] (argument clamped for acos safety)
+    θ = acos(clamp(cos(ϕ) * cos(δ) * cos(η) + sin(ϕ) * sin(δ), FT(-1), FT(1)))
 
     # Solar azimuth angle: ζ = 0 when due E and increasing CCW
-    # ζ = 3π/2 (due S) when η=0 at local solar noon
-    ζ = mod(FT(3π / 2) - atan(sin(η), cos(η) * sin(ϕ) - tan(δ) * cos(ϕ)), FT(2π))
+    # ζ = 3π/2 (due S) when η=0 at local solar noon.
+    # The arguments are multiplied through by cos(δ) ≥ 0 to avoid the tan(δ)
+    # singularity at high declinations (e.g., extreme obliquity).
+    ζ = mod(
+        FT(3π / 2) -
+        atan(cos(δ) * sin(η), cos(δ) * cos(η) * sin(ϕ) - sin(δ) * cos(ϕ)),
+        FT(2π),
+    )
 
     return (; d, θ, ζ)
 end
@@ -314,22 +384,25 @@ end
 """
     daily_distance_zenith_angle(
         date::DateTime,
-        latitude::FT,
-        (ϖ, γ, e)::Tuple{FT, FT, FT},
+        latitude::Real,
+        orb_params::Tuple{<:Real, <:Real, <:Real},
         param_set::IP.AIP,
-    ) where {FT <: Real}
+    )
 
-Calculates the effective zenith angle for diurnally averaged insolation and 
+Calculate the effective zenith angle for diurnally averaged insolation and the
 planet-star distance.
 
-Returns the effective zenith angle corresponding to the diurnally
-averaged insolation (averaging cos(zenith angle) over 24 hours) and 
-the planet-star distance for a given date and latitude.
+Return the effective zenith angle corresponding to the diurnally averaged
+insolation (averaging the cosine of the zenith angle over 24 hours) and the
+planet-star distance for a given date and latitude.
+
+All real-valued inputs are converted to `eltype(param_set)` internally, so the
+computation is carried out consistently in the parameter set's floating-point type.
 
 # Arguments
 - `date::DateTime`: Current date
-- `latitude::FT`: Latitude [degrees]
-- `(ϖ, γ, e)::Tuple{FT, FT, FT}`: Orbital parameters tuple containing:
+- `latitude::Real`: Latitude [degrees]
+- `orb_params::Tuple{<:Real, <:Real, <:Real}`: Orbital parameters tuple `(ϖ, γ, e)`:
   - `ϖ`: Longitude of perihelion [radians]
   - `γ`: Obliquity (axial tilt) [radians]
   - `e`: Orbital eccentricity [unitless]
@@ -337,34 +410,39 @@ the planet-star distance for a given date and latitude.
 
 # Returns
 A `NamedTuple` with fields:
-- `d`: Planet-star distance [m]
 - `daily_θ`: Effective solar zenith angle [radians]
+- `d`: Planet-star distance, in units of the semi-major axis [unitless]
 """
 function daily_distance_zenith_angle(
     date::DateTime,
-    latitude::FT,
-    (ϖ, γ, e)::Tuple{FT,FT,FT},
-    param_set::IP.AIP;
-) where {FT}
-    ϕ = deg2rad(latitude)
+    latitude::Real,
+    orb_params::Tuple{<:Real,<:Real,<:Real},
+    param_set::IP.AIP,
+)
+    FT = eltype(param_set)
+    # Convert all inputs to the parameter set's float type for type consistency
+    ϖ, γ, e = FT.(orb_params)
+    ϕ = FT(deg2rad(latitude))
 
     Δt_years = years_since_epoch(param_set, date)
 
     # Get distance and declination
     d, δ, _ = distance_declination_mean_anomaly(Δt_years, (ϖ, γ, e), param_set)
 
-    # Sunrise/sunset hour angle 
-    T = tan(ϕ) * tan(δ)
-    # Clamp T to valid acos range and compute
-    T_clamped = clamp(T, FT(-1), FT(1))
-    ηd_normal = acos(-T_clamped)
-    # Use ifelse to select: polar day (π), polar night (0), or normal
-    ηd = ifelse(T >= FT(1), FT(π), ifelse(T <= FT(-1), FT(0), ηd_normal))
+    # Sunrise/sunset hour angle. Clamping the argument to [-1, 1] also encodes the
+    # polar limits in a single branchless expression: clamp gives acos(-1) = π for
+    # polar day (tanϕ·tanδ ≥ 1) and acos(1) = 0 for polar night (tanϕ·tanδ ≤ -1).
+    ηd = acos(clamp(-tan(ϕ) * tan(δ), FT(-1), FT(1)))
 
     # Effective zenith angle to get diurnally averaged insolation
-    # (i.e., averaging cosine of zenith angle)
-    daily_θ =
-        mod(acos(FT(1 / π) * (ηd * sin(ϕ) * sin(δ) + cos(ϕ) * cos(δ) * sin(ηd))), FT(2π))
+    # (i.e., averaging the cosine of the zenith angle). The argument is clamped
+    # to [-1, 1] to guard against floating-point overshoot in acos.
+    daily_cosθ = clamp(
+        FT(1 / π) * (ηd * sin(ϕ) * sin(δ) + cos(ϕ) * cos(δ) * sin(ηd)),
+        FT(-1),
+        FT(1),
+    )
+    daily_θ = acos(daily_cosθ)
 
     return (; daily_θ, d)
 end

--- a/test/test_perihelion.jl
+++ b/test/test_perihelion.jl
@@ -14,7 +14,8 @@
         ϖ, γ, e = orbital_params(od, Δt_years)
         orb_params = (FT(ϖ), FT(γ), FT(e))
         result = daily_distance_zenith_angle(date, FT(0), orb_params, param_set)
-        return result.d / IP.orbit_semimaj(param_set)
+        # result.d is already in units of the semi-major axis
+        return result.d
     end
 
     years = 1900:2100

--- a/test/test_physical_consistency.jl
+++ b/test/test_physical_consistency.jl
@@ -138,17 +138,14 @@ end
 end
 
 @testset "Physical Consistency - Earth-Sun Distance Bounds" begin
-    # Earth-Sun distance should be within known bounds
-    # Perihelion: ~147.1 million km
-    # Aphelion: ~152.1 million km
-
-    d0 = IP.orbit_semimaj(param_set)
+    # Earth-Sun distance (in units of the semi-major axis) should be within known
+    # bounds: perihelion at 1 - e and aphelion at 1 + e.
     e = IP.eccentricity_epoch(param_set)
 
-    # Perihelion distance
-    d_peri = d0 * (1 - e)
-    # Aphelion distance  
-    d_aph = d0 * (1 + e)
+    # Perihelion distance (units of semi-major axis)
+    d_peri = 1 - e
+    # Aphelion distance (units of semi-major axis)
+    d_aph = 1 + e
 
     # Sample various dates
     dates = [Dates.DateTime(2000, m, 15) for m = 1:12]

--- a/test/test_zenith_angle.jl
+++ b/test/test_zenith_angle.jl
@@ -83,4 +83,5 @@ date = Dates.DateTime(2000, 3, 22, 0, 0, 0)
 ϖ, γ, e = orbital_params(od, Δt_years)
 orb_params = (FT(ϖ), FT(γ), FT(e))
 (; d, θ, ζ) = solar_geometry(date, lat, lon, orb_params, param_set)
-@test d ≈ IP.orbit_semimaj(param_set) rtol = rtol
+# d is in units of the semi-major axis; near the equinox it is ≈ 1
+@test d ≈ 1 rtol = rtol


### PR DESCRIPTION
## Documentation
* Fixed an incorrect physical claim (equator-equinox daily-mean cosine is 1/π ≈ 0.318, not 2/π), clarified the non-standard azimuth convention, and corrected several stale/typo'd docstring examples (including broken ; milankovitch=true keyword calls and a adapt(CuArray, TSIDataSpline) typo).
* Standardized docstrings, added missing # Fields/# Returns/cross-reference sections, and added a type-level docstring for InsolationParameters.
* Made the manual-parameter examples consistent and physically accurate.

## Code
* Bug: TSIDataSpline's evaluate selected the wrong monthly interval for dates after the 15th but before noon, producing a small (1e-3 W/m2) non-physical discontinuity. Fixed the branch condition.
* Bug: the Milankovitch path indexed the Laskar (2004) tables (Julian-year axis) with anomalistic years. Added julian_years_since_epoch and use it for the spline lookup, keeping anomalistic years for the mean anomaly.
* Breaking change: Removed semi-major axis from parameters and expressed all distances as normalized by semi-major axis. This does not affect any CliMA consumers but is a breaking change of the API.
* Robustness: solar_geometry/daily_distance_zenith_angle now convert all inputs to eltype(param_set) (removes silent float-type mixing); cleared the tan(δ) singularity in the azimuth, added clamp to the daily acos, and removed several no-op mod(·, 2π) calls.

## Bump minor version
* Bumped minor version to reflect breaking change in API 
* API change has no effect on ClimaAtmos, ClimaLand etc. No source code changes needed
* However, there are tiny changes in insolation, e.g., from the more accurate equation of time (the difference is less than 45 s time shift everywhere). They don't matter in practice, but if there are bitwise reproducibility tests (e.g.,. in atmos) that depend on exact insolation, they'd break. 