### PR TITLE
Pin JuliaFormatter to v2.10.1

### DIFF
--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -3,4 +3,4 @@ Insolation = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 
 [compat]
-JuliaFormatter = "1"
+JuliaFormatter = "=2.10.1"

--- a/src/SolarGeometry.jl
+++ b/src/SolarGeometry.jl
@@ -373,8 +373,7 @@ function solar_geometry(
     # The arguments are multiplied through by cos(δ) ≥ 0 to avoid the tan(δ)
     # singularity at high declinations (e.g., extreme obliquity).
     ζ = mod(
-        FT(3π / 2) -
-        atan(cos(δ) * sin(η), cos(δ) * cos(η) * sin(ϕ) - sin(δ) * cos(ϕ)),
+        FT(3π / 2) - atan(cos(δ) * sin(η), cos(δ) * cos(η) * sin(ϕ) - sin(δ) * cos(ϕ)),
         FT(2π),
     )
 
@@ -437,11 +436,8 @@ function daily_distance_zenith_angle(
     # Effective zenith angle to get diurnally averaged insolation
     # (i.e., averaging the cosine of the zenith angle). The argument is clamped
     # to [-1, 1] to guard against floating-point overshoot in acos.
-    daily_cosθ = clamp(
-        FT(1 / π) * (ηd * sin(ϕ) * sin(δ) + cos(ϕ) * cos(δ) * sin(ηd)),
-        FT(-1),
-        FT(1),
-    )
+    daily_cosθ =
+        clamp(FT(1 / π) * (ηd * sin(ϕ) * sin(δ) + cos(ϕ) * cos(δ) * sin(ηd)), FT(-1), FT(1))
     daily_θ = acos(daily_cosθ)
 
     return (; daily_θ, d)

--- a/test/test_gpu.jl
+++ b/test/test_gpu.jl
@@ -91,16 +91,15 @@ if CUDA_AVAILABLE
                     )
                     F_cpu, S_cpu, μ_cpu, ζ_cpu =
                         result_cpu3.F, result_cpu3.S, result_cpu3.μ, result_cpu3.ζ
-                    result =
-                        insolation.(
-                            date,
-                            lat_gpu,
-                            lon_gpu,
-                            params,
-                            od_gpu,
-                            milankovitch,
-                            tsi_gpu,
-                        )
+                    result = insolation.(
+                        date,
+                        lat_gpu,
+                        lon_gpu,
+                        params,
+                        od_gpu,
+                        milankovitch,
+                        tsi_gpu,
+                    )
                     result_gpu_arr = Array(result)[1]
                     F_gpu, S_gpu, μ_gpu, ζ_gpu = result_gpu_arr.F,
                     result_gpu_arr.S,
@@ -130,43 +129,42 @@ if CUDA_AVAILABLE
                 # Test broadcasting over multiple values
                 @testset "Broadcasting over multiple locations" begin
                     for (
-                        maybe_od_cpu,
-                        maybe_od_gpu,
-                        milankovitch,
-                        maybe_tsi_cpu,
-                        maybe_tsi_gpu,
-                    ) in combinations
+                            maybe_od_cpu,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_cpu,
+                            maybe_tsi_gpu,
+                        ) in combinations
+
                         n = 100
                         lats_cpu = FT.(range(-90, 90, length = n))
                         lons_cpu = FT.(range(-180, 180, length = n))
 
                         # Compute on CPU
-                        results_cpu =
-                            insolation.(
-                                date,
-                                lats_cpu,
-                                lons_cpu,
-                                params,
-                                maybe_od_cpu,
-                                milankovitch,
-                                maybe_tsi_cpu,
-                            )
+                        results_cpu = insolation.(
+                            date,
+                            lats_cpu,
+                            lons_cpu,
+                            params,
+                            maybe_od_cpu,
+                            milankovitch,
+                            maybe_tsi_cpu,
+                        )
 
                         # Transfer to GPU
                         lats_gpu = CuArray(lats_cpu)
                         lons_gpu = CuArray(lons_cpu)
 
                         # Compute on GPU
-                        results_gpu =
-                            insolation.(
-                                date,
-                                lats_gpu,
-                                lons_gpu,
-                                params,
-                                maybe_od_gpu,
-                                milankovitch,
-                                maybe_tsi_gpu,
-                            )
+                        results_gpu = insolation.(
+                            date,
+                            lats_gpu,
+                            lons_gpu,
+                            params,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_gpu,
+                        )
 
                         # Bring back to CPU
                         results_gpu_cpu = Array(results_gpu)
@@ -195,12 +193,13 @@ if CUDA_AVAILABLE
                 # Test daily_insolation
                 @testset "daily_insolation on GPU" begin
                     for (
-                        maybe_od_cpu,
-                        maybe_od_gpu,
-                        milankovitch,
-                        maybe_tsi_cpu,
-                        maybe_tsi_gpu,
-                    ) in combinations
+                            maybe_od_cpu,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_cpu,
+                            maybe_tsi_gpu,
+                        ) in combinations
+
                         lat_gpu = CuArray([lat_cpu])
 
                         # Compute reference on CPU
@@ -216,15 +215,14 @@ if CUDA_AVAILABLE
                             result_daily_cpu.F, result_daily_cpu.S, result_daily_cpu.μ
 
                         # Run on GPU
-                        result =
-                            daily_insolation.(
-                                date,
-                                lat_gpu,
-                                params,
-                                maybe_od_gpu,
-                                milankovitch,
-                                maybe_tsi_gpu,
-                            )
+                        result = daily_insolation.(
+                            date,
+                            lat_gpu,
+                            params,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_gpu,
+                        )
 
                         # Bring back to CPU
                         result_daily_gpu = Array(result)[1]
@@ -241,12 +239,13 @@ if CUDA_AVAILABLE
                 # Test with different times
                 @testset "Multiple dates" begin
                     for (
-                        maybe_od_cpu,
-                        maybe_od_gpu,
-                        milankovitch,
-                        maybe_tsi_cpu,
-                        maybe_tsi_gpu,
-                    ) in combinations
+                            maybe_od_cpu,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_cpu,
+                            maybe_tsi_gpu,
+                        ) in combinations
+
                         dates = [
                             DateTime(2024, 3, 20, 12, 0, 0),  # Equinox
                             DateTime(2024, 6, 21, 12, 0, 0),  # Summer solstice
@@ -257,31 +256,29 @@ if CUDA_AVAILABLE
                         lons = FT.([0.0, 0.0, 180.0, 0.0])
 
                         # CPU computation
-                        results_cpu =
-                            insolation.(
-                                dates,
-                                lats,
-                                lons,
-                                params,
-                                maybe_od_cpu,
-                                milankovitch,
-                                maybe_tsi_cpu,
-                            )
+                        results_cpu = insolation.(
+                            dates,
+                            lats,
+                            lons,
+                            params,
+                            maybe_od_cpu,
+                            milankovitch,
+                            maybe_tsi_cpu,
+                        )
 
                         # GPU computation
                         lats_gpu = CuArray(lats)
                         lons_gpu = CuArray(lons)
                         dates_gpu = CuArray(dates)
-                        results_gpu =
-                            insolation.(
-                                dates_gpu,
-                                lats_gpu,
-                                lons_gpu,
-                                params,
-                                maybe_od_gpu,
-                                milankovitch,
-                                maybe_tsi_gpu,
-                            )
+                        results_gpu = insolation.(
+                            dates_gpu,
+                            lats_gpu,
+                            lons_gpu,
+                            params,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_gpu,
+                        )
 
                         # Compare
                         results_gpu_cpu = Array(results_gpu)
@@ -308,12 +305,12 @@ if CUDA_AVAILABLE
                 # Test edge cases
                 @testset "Edge cases on GPU" begin
                     for (
-                        maybe_od_cpu,
-                        maybe_od_gpu,
-                        milankovitch,
-                        maybe_tsi_cpu,
-                        maybe_tsi_gpu,
-                    ) in combinations
+                            maybe_od_cpu,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_cpu,
+                            maybe_tsi_gpu,
+                        ) in combinations
                         # Polar night
                         result_cpu = insolation(
                             DateTime(2024, 12, 21, 12, 0, 0),
@@ -324,16 +321,15 @@ if CUDA_AVAILABLE
                             milankovitch,
                             maybe_tsi_cpu,
                         )
-                        result_gpu =
-                            insolation.(
-                                DateTime(2024, 12, 21, 12, 0, 0),
-                                CuArray([FT(80.0)]),
-                                CuArray([FT(0.0)]),
-                                params,
-                                maybe_od_gpu,
-                                milankovitch,
-                                maybe_tsi_gpu,
-                            )
+                        result_gpu = insolation.(
+                            DateTime(2024, 12, 21, 12, 0, 0),
+                            CuArray([FT(80.0)]),
+                            CuArray([FT(0.0)]),
+                            params,
+                            maybe_od_gpu,
+                            milankovitch,
+                            maybe_tsi_gpu,
+                        )
                         result_gpu_cpu = Array(result_gpu)[1]
 
                         @test result_gpu_cpu[1] ≈ result_cpu[1] rtol = 1e-5  # F

--- a/test/test_insolation.jl
+++ b/test/test_insolation.jl
@@ -72,8 +72,8 @@ for (i, lat) in enumerate(l_arr)
     local (; F, S, μ) = insolation(daily_θ, d, param_set)
     F_arr[i] = F
 end
-F_NH = sort(F_arr[l_arr.>=0])
-F_SH = sort(F_arr[l_arr.<=0])
+F_NH = sort(F_arr[l_arr .>= 0])
+F_SH = sort(F_arr[l_arr .<= 0])
 @test F_NH ≈ F_SH rtol = rtol
 
 ## Test globally averaged insolation ≈ TSI


### PR DESCRIPTION
## Summary
- Pin JuliaFormatter to an exact version (`2.10.1`) in `.dev/Project.toml` (used by the formatter GitHub Action) so formatting is reproducible across CI and local runs.
- Reformat the codebase with JuliaFormatter v2.10.1 (whitespace/style only, no logic changes).

See [Pinning the JuliaFormatter version](https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status/#Pinning-the-JuliaFormatter-version) for why pinning is recommended.

## Test plan
- [x] `git diff` reviewed — formatting-only changes
- [ ] CI passes